### PR TITLE
add support for multiple lineages

### DIFF
--- a/bin/filter_msa_align.py
+++ b/bin/filter_msa_align.py
@@ -14,19 +14,21 @@ from collections import Counter
 @click.option("-r", "--lineage-report", help="Pangolin report of input sequences", type=click.Path(exists=False),
               required=False, default='')
 @click.option("-R", "--ref-name", help="Name of reference sequence", required=False, type=str, default='MN908947.3')
-@click.option("-c", "--country", help="Keep the sequences of country that want to focus", required=False, type=str, default='Canada')
-@click.option("-t", "--threshold", help="The threshold to filter down sequences in MSA to managebale number", required=False, type=int,
+@click.option("-c", "--country", help="Keep the sequences of country that want to focus", required=False, type=str,
+              default='Canada')
+@click.option("-t", "--threshold", help="The threshold to filter down sequences in MSA to managebale number",
+              required=False, type=int,
               default=10000)
 @click.option("-o", "--fasta-output", help="Multiple Sequence Alignment after filtering", type=click.Path(exists=False),
               required=False)
 @click.option("-m", "--metadata-output", help="Metadata file of Multiple Sequence Alignment after filtering ",
               type=click.Path(exists=False), required=False)
 def main(msa_sequences, metadata_input, lineage_report, ref_name, country, threshold, fasta_output, metadata_output):
-
     # Read Metadata of Multiple Sequence Alignment
     df_metadata_msa = pd.read_table(metadata_input, sep='\t')
-    if len(df_metadata_msa) > threshold: # only filter when number of MSA sequences > 10000
-        df_metadata_output = pd.DataFrame(columns = df_metadata_msa.columns)
+
+    if len(df_metadata_msa) > threshold:  # only filter when number of MSA sequences > 10000
+        df_metadata_output = pd.DataFrame(columns=df_metadata_msa.columns)
 
         # df_input_metadata = pd.read_table(lineage_report, sep='\t')
         df_lineage_report = pd.read_table(lineage_report, sep=',')
@@ -37,7 +39,6 @@ def main(msa_sequences, metadata_input, lineage_report, ref_name, country, thres
 
         # Keep 1 representative sequence however keep it if it is same as Canada sequences or input_sequences_strains
         seq_strain_dict = {}
-        drop = 0
         with open(msa_sequences) as fin:
             for strains, seq in SimpleFastaParser(fin):
                 if strains in input_sequences_strains or country in strains:
@@ -66,7 +67,8 @@ def main(msa_sequences, metadata_input, lineage_report, ref_name, country, thres
             seq_key = seq_key.upper()
             seq_nt = sum(seq_key.count(x) for x in list('AGCT'))
             skip = False
-            if any(country in values for values in strains_value) or any(item in input_sequences_strains for item in strains_value) :
+            if any(country in values for values in strains_value) or any(
+                    item in input_sequences_strains for item in strains_value):
                 skip = True
             seq_recs.append(dict(strain=strains_value,
                                  seq_n=seq_key.count('N'),
@@ -76,38 +78,52 @@ def main(msa_sequences, metadata_input, lineage_report, ref_name, country, thres
         df_seq_recs = pd.DataFrame(seq_recs)
         # Create skip strains
         df_skip_strains = df_seq_recs[df_seq_recs['skip_strains'] == True]
-
         skip_strains = (df_skip_strains['strain']).tolist()
 
         df_percentile_75 = df_seq_recs.describe()
-
         seq_n_75 = df_percentile_75.loc['75%', 'seq_n']
-        seq_gap_75= df_percentile_75.loc['75%', 'seq_gap']
+        seq_gap_75 = df_percentile_75.loc['75%', 'seq_gap']
 
         df_less_n_gaps = df_seq_recs.query('seq_n <= @seq_n_75 and seq_gap <= @seq_gap_75')
-        #df_less_n_gaps = df_seq_recs.query('seq_n <= 60 and seq_gap <= @seq_gap_75')
-        sampled_strains = df_less_n_gaps.strain.sample(n=(threshold - len(df_skip_strains))).tolist()
 
-        for item in skip_strains:
-            if item not in sampled_strains:
-                sampled_strains.append(item)
+        # After filtering, the total of sequences <=10000, so need to sample
+        if len(df_less_n_gaps) <= threshold:
+            sampled_strains = df_less_n_gaps['strain'].tolist()
+            with open(fasta_output, 'w') as fout:
+                for seq_key, strains_value in seq_strain_dict.items():
+                    for strains_list in sampled_strains:
+                        if strains_value == strains_list:
+                            for strain in strains_list:
+                                row_index = df_metadata_msa.loc[df_metadata_msa['Virus_name'] == strain].index
+                                df_metadata_output = df_metadata_output.append(df_metadata_msa.loc[row_index])
+                                fout.write(f'>{strain}\n{seq_key}\n')
+                            break
+            df_metadata_output.to_csv(metadata_output, sep='\t', index=False)
+        # After filtering, the total of sequences >10000, sample to manageable number of sequences
 
-        with open(fasta_output, 'w') as fout:
-            for seq_key, strains_value in seq_strain_dict.items():
-                for strains_list in sampled_strains:
-                    if strains_value == strains_list:
-                        for strain in strains_list:
-                            row_index = df_metadata_msa.loc[df_metadata_msa['Virus_name'] == strain].index
-                            df_metadata_output = df_metadata_output.append(df_metadata_msa.loc[row_index])
-                            fout.write(f'>{strain}\n{seq_key}\n')
-                        break
-        df_metadata_output.to_csv(metadata_output, sep='\t', index=False)
+        else:
+            sampled_strains = df_less_n_gaps.strain.sample(n=(threshold - len(df_skip_strains))).tolist()
+            for item in skip_strains:
+                if item not in sampled_strains:
+                    sampled_strains.append(item)
+            with open(fasta_output, 'w') as fout:
+                for seq_key, strains_value in seq_strain_dict.items():
+                    for strains_list in sampled_strains:
+                        if strains_value == strains_list:
+                            for strain in strains_list:
+                                row_index = df_metadata_msa.loc[df_metadata_msa['Virus_name'] == strain].index
+                                df_metadata_output = df_metadata_output.append(df_metadata_msa.loc[row_index])
+                                fout.write(f'>{strain}\n{seq_key}\n')
+                            break
+            df_metadata_output.to_csv(metadata_output, sep='\t', index=False)
+
     else:
         df_metadata_msa.to_csv(metadata_output, sep='\t', index=False)
         with open(fasta_output, 'w') as fout:
             with open(msa_sequences) as fin:
                 for strains, seq in SimpleFastaParser(fin):
                     fout.write(f'>{strains}\n{seq}\n')
+
 
 if __name__ == '__main__':
     main()

--- a/bin/prune_down_tree.py
+++ b/bin/prune_down_tree.py
@@ -23,20 +23,21 @@ def main(newick_tree_input, metadata_input, metadata_output, ref_name, lineage_r
         df_metadata_output = pd.DataFrame(columns=df_metadata_input.columns)
 
         df_lineage_report = pd.read_table(lineage_report, sep=',')
-        interest_taxa = df_lineage_report['taxon'].tolist()[0]
-
-        clade_ncfad = list(tree.find_elements(target=interest_taxa))[0]
-
         clade_neighbors = set()
-        for i, c in enumerate(tree.get_path(clade_ncfad)[::-1]):
-            n_terminals = c.count_terminals()
-            if n_terminals <= max_taxa:
-                for nc in c.get_terminals():
-                    clade_neighbors.add(nc.name)
-            else:
-                break
+        clade_neighbors.add(ref_name)
+        interest_taxa = df_lineage_report['taxon'].tolist()
+
+        for tax in interest_taxa:
+            clade_ncfad = list(tree.find_elements(target=tax))[0]
+            for i, c in enumerate(tree.get_path(clade_ncfad)[::-1]):
+                n_terminals = c.count_terminals()
+                if n_terminals <= max_taxa:
+                    for nc in c.get_terminals():
+                        clade_neighbors.add(nc.name)
+                else:
+                    break
         with open('leaflist', 'w') as fout:
-            fout.write(ref_name+'\n')
+            #fout.write(ref_name+'\n')
             for x in clade_neighbors:
                 row_index = df_metadata_input.loc[df_metadata_input['Virus_name'] == x].index
                 df_metadata_output = df_metadata_output.append(df_metadata_input.loc[row_index])


### PR DESCRIPTION
The workflow needs to  support multiple lineages (address the issue https://github.com/nhhaidee/scovtree/issues/19).

1. The filtering gisaid sequence is OK, as it get all interest strain, lineages.
2. The filtering multiple sequence align steps: working on suggestion
   >I think it would be more appropriate to be biased towards including samples from the low abundance lineages before the larger lineages
3. Updated `bin/prune_down_tree.py` : to support multiple lineages
https://github.com/nhhaidee/scovtree/blob/f45df37b278241cf110b06b0abf5bb77e3f15493/bin/prune_down_tree.py#L28-L38
